### PR TITLE
fix from get-upgrades to get-versions

### DIFF
--- a/Kubernetes-Workshop2.md
+++ b/Kubernetes-Workshop2.md
@@ -279,7 +279,7 @@ $ az aks scale --name esakscluster --resource-group MCACS-AKS --node-count 7
 Confirm the available upgrade version in your environment. For following example, you can upgrade to 1.8.7 as latest.
 
 ```
-$ az aks get-upgrades --name esakscluster --resource-group MCACS-AKS
+$ az aks get-versions --name esakscluster --resource-group MCACS-AKS
 {
   "additionalProperties": {},
   "agentPoolProfiles": [


### PR DESCRIPTION
I have tried this section. Then I found invalid command. Details below,

```
az aks get-upgrades --name esakscluster --resource-group MCACS-AKS
az aks: error: argument _subcommand: invalid choice: get-upgrades
usage: az aks [-h]
              {browse,create,delete,get-credentials,get-versions,install-cli,install-connector,list,remove-connector,scale,show,upgrade,wait}
              ...
```