### PR TITLE
Add workspace path to COPY cmd.

### DIFF
--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -17,6 +17,6 @@ FROM payara/micro:5.182
 LABEL MAINTAINER Yoshio Terada
 
 
-COPY --from=BUILD target/*.war $DEPLOY_DIR/ROOT.war
+COPY --from=BUILD /usr/src/myapp/target/*.war $DEPLOY_DIR/ROOT.war
 #COPY target/*.war $DEPLOY_DIR/ROOT.war
 EXPOSE 8080


### PR DESCRIPTION
When executing the front `docker build` , the build fails due to war file path indicates incorecct path.
I fixed Dockerfile.

output below:
```
(snip)
Step 6/9 : FROM payara/micro:5.182
5.182: Pulling from payara/micro
ff3a5c916c92: Pull complete
a8906544047d: Pull complete
ae9db8d675e1: Pull complete
288b580dc3a6: Pull complete
e6962c9c3aaf: Pull complete
Digest: sha256:2adfa2d0abae0ab304d300c915288c6a18349655c08e31bf6037255d2c503ee0
Status: Downloaded newer image for payara/micro:5.182
 ---> 6e6fbc26ba0e
Step 7/9 : LABEL MAINTAINER Yoshio Terada
 ---> Running in ba2d40787179
Removing intermediate container ba2d40787179
 ---> 22460cfd98b0
Step 8/9 : COPY --from=BUILD target/*.war $DEPLOY_DIR/ROOT.war
COPY failed: no source files were specified
```